### PR TITLE
PHPUnit\Framework\TestCase ao invés de PHPUnit_Framework_TestCase

### DIFF
--- a/tests/Common/EntitiesCharactersTest.php
+++ b/tests/Common/EntitiesCharactersTest.php
@@ -3,8 +3,9 @@
 namespace NFePHP\NFSe\Tests\Common;
 
 use NFePHP\NFSe\Common\EntitiesCharacters;
+use PHPUnit\Framework\TestCase;
 
-class EntitiesCharactersTest extends \PHPUnit_Framework_TestCase
+class EntitiesCharactersTest extends TestCase
 {
     public function testUnConvert()
     {
@@ -13,7 +14,7 @@ class EntitiesCharactersTest extends \PHPUnit_Framework_TestCase
         $expected = 'Esse [0xc3][0xa9] um teste de convers[0xc3][0xa3]o';
         $this->assertEquals($expected, $actual);
     }
-    
+
     public function testConvert()
     {
         $subject = 'Esse [0xc3][0xa9] um teste de convers[0xc3][0xa3]o';

--- a/tests/NFSeTestCase.php
+++ b/tests/NFSeTestCase.php
@@ -2,13 +2,15 @@
 
 namespace NFePHP\NFSe\Tests;
 
-class NFSeTestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class NFSeTestCase extends TestCase
 {
     public $fixturesPath = '';
     public $configJson = '';
     public $contentpfx = '';
     public $passwordpfx = '';
-    
+
     public function __construct()
     {
         $this->fixturesPath = dirname(__FILE__) . '/fixtures/';
@@ -28,7 +30,7 @@ class NFSeTestCase extends \PHPUnit_Framework_TestCase
                 "proxyPort" => "",
                 "proxyUser" => "",
                 "proxyPass" => ""
-            ]    
+            ]
         ];
         $this->contentpfx = file_get_contents($this->fixturesPath . "certs/certificado_teste.pfx");
         $this->passwordpfx = "associacao";


### PR DESCRIPTION
Usei `PHPUnit\Framework\TestCase` ao invés de `PHPUnit_Framework_TestCase` enquanto extendendo a classe `PHPUnit TestCase`. Isso irá nos ajudar quando migrarmos para o `PHPUnit 6`, que [não mais suporta _snake case namespaces_](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).